### PR TITLE
Add  IBaseNode.getModifiableChildren 

### DIFF
--- a/src/main/java/it/unitn/disi/smatch/data/trees/BaseNode.java
+++ b/src/main/java/it/unitn/disi/smatch/data/trees/BaseNode.java
@@ -205,7 +205,21 @@ public class BaseNode<E extends IBaseNode, I extends IBaseNodeData> extends Inde
         }
     }
 
+    @Override
+    public List<E> getModifiableChildren() {
+        if (null != children) {
+            return children;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+    
     public void setChildren(List<E> children) {
+
+        for (E child : children){
+            checkChild(child);
+        }
+        
         this.children = children;
     }
 
@@ -233,12 +247,9 @@ public class BaseNode<E extends IBaseNode, I extends IBaseNodeData> extends Inde
     @Override
     @SuppressWarnings({"unchecked"})
     public void addChild(int index, E child) {
-        if (null == child) {
-            throw new IllegalArgumentException("new child is null");
-        } else if (isAncestor(child)) {
-            throw new IllegalArgumentException("new child is an ancestor");
-        }
-
+        
+        checkChild(child);
+        
         IBaseNode oldParent = child.getParent();
 
         if (null != oldParent) {
@@ -484,4 +495,17 @@ public class BaseNode<E extends IBaseNode, I extends IBaseNodeData> extends Inde
     private boolean isChild(E node) {
         return null != node && 0 != getChildCount() && node.getParent() == this && -1 < children.indexOf(node);
     }
+    
+    /**
+     * @since 2.0.0
+     * @throws IllegalArgumentException
+     */
+    private void checkChild(E child) {
+        if (null == child) {
+            throw new IllegalArgumentException("new child is null");
+        } else if (isAncestor(child)) {
+            throw new IllegalArgumentException("new child is an ancestor");
+        }
+    }
+
 }

--- a/src/main/java/it/unitn/disi/smatch/data/trees/IBaseNode.java
+++ b/src/main/java/it/unitn/disi/smatch/data/trees/IBaseNode.java
@@ -42,6 +42,16 @@ public interface IBaseNode<E extends IBaseNode, I extends IBaseNodeData> extends
      * @return unmodifiable list of receivers children
      */
     List<E> getChildren();
+    
+    /**
+     * Returns a list of children that can be modified. 
+     * Notice that acting on this list won't fire events.
+     * 
+     * @see {@link #setChildren(List)}
+     * @see {@link #children()}
+     * @since 2.0.0
+     */
+    public List<E> getModifiableChildren();
 
     /**
      * Sets list of children.


### PR DESCRIPTION

This pull request eases modifying a node tree by adding the `getModifiableChildren()` method. 
It was needed by @gbella to implement SPSM filtering for  unordered Tree Edit Distance (TED), see [here](https://github.com/s-match/s-match-spsm/blob/264a8a2a07c1cba124487db2107f3ef06d93c382/src/main/java/it/unitn/disi/smatch/filters/SPSMMappingFilter.java#L183) for an example invocation.

It's a bit hacky, but seems like without it algorithms that need to modify trees get a lot more complicated.

