### PR TITLE
Fix inconsistent node update system 

### DIFF
--- a/src/main/java/it/unitn/disi/smatch/data/trees/BaseNode.java
+++ b/src/main/java/it/unitn/disi/smatch/data/trees/BaseNode.java
@@ -205,21 +205,13 @@ public class BaseNode<E extends IBaseNode, I extends IBaseNodeData> extends Inde
         }
     }
 
-    @Override
-    public List<E> getModifiableChildren() {
-        if (null != children) {
-            return children;
-        } else {
-            return Collections.emptyList();
-        }
-    }
     
     public void setChildren(List<E> children) {
         for (E child : children){
             checkChild(child);
         }
         
-        this.children = children;
+        this.children = new ArrayList<>(children);
     }
 
     @Override

--- a/src/main/java/it/unitn/disi/smatch/data/trees/IBaseNode.java
+++ b/src/main/java/it/unitn/disi/smatch/data/trees/IBaseNode.java
@@ -43,18 +43,11 @@ public interface IBaseNode<E extends IBaseNode, I extends IBaseNodeData> extends
      */
     List<E> getChildren();
     
-    /**
-     * Returns a list of children that can be modified. 
-     * Notice that acting on this list won't fire events.
-     * 
-     * @see {@link #setChildren(List)}
-     * @see {@link #children()}
-     * @since 2.0.0
-     */
-    public List<E> getModifiableChildren();
 
     /**
-     * Sets list of children.
+     * Sets list of children. Implementations should avoid storing
+     * directly the container to prevent accidental further changes
+     * by the caller.
      *
      * @param children new list of children
      */
@@ -94,11 +87,13 @@ public interface IBaseNode<E extends IBaseNode, I extends IBaseNodeData> extends
      * Removes the child at index from the receiver.
      *
      * @param index index of a child to remove
+     * 
+     * @throws IndexOutOfBoundsException - if the index is out of range (index < 0 || index >= size())
      */
     void removeChild(int index);
 
     /**
-     * Removes node from the receiver.
+     * Removes node from the receiver. If node is not present, does nothing.
      *
      * @param node child to remove
      */

--- a/src/test/java/it/unitn/disi/smatch/test/data/trees/NodeTest.java
+++ b/src/test/java/it/unitn/disi/smatch/test/data/trees/NodeTest.java
@@ -1,0 +1,50 @@
+package it.unitn.disi.smatch.test.data.trees;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import it.unitn.disi.smatch.data.trees.INode;
+import it.unitn.disi.smatch.data.trees.Node;
+
+/**
+* @since 2.0.0
+*/
+public class NodeTest {
+
+    /**
+     * Shows setParent is not looping, see https://github.com/s-match/s-match-core/issues/7
+     * 
+     * @since 2.0.0
+     */
+    @Test
+    public void testNode(){
+        Node parent = new Node();
+        
+        Node node = new Node();
+        
+        node.setParent(parent);
+    }
+
+    /**
+     * Shows setChidren should store a copy of the array, 
+     * see https://github.com/s-match/s-match-core/issues/7
+     * 
+     * @since 2.0.0
+     */    
+    @Test
+    public void testSetChildren(){
+        Node nodeA = new Node();
+        Node nodeB = new Node();
+        
+        List<INode> children = new ArrayList<>();
+        nodeA.setChildren(children);
+        children.add(nodeB);        
+        assertEquals(0, nodeA.getChildCount());
+        
+    }
+    
+}


### PR DESCRIPTION
Fix for #7 

- `BaseNode.setChildren` now stores a copy of the data
- Removed the evil `IBaseNode.getModifiableChildren()` introduced in #6
- added some Javadoc and tests